### PR TITLE
fix: Remove repeated scanner

### DIFF
--- a/components/AppHeader2/core.tsx
+++ b/components/AppHeader2/core.tsx
@@ -198,14 +198,6 @@ export default function AppHeader2_Core(props: Props) {
                           },
                         ]
                       : []),
-                    ...(isAdmin
-                      ? [
-                          {
-                            optionName: 'Scanner',
-                            onClick: () => router.push('/admin/scan'),
-                          },
-                        ]
-                      : []),
                   ]}
                 />
               </div>


### PR DESCRIPTION
There was 2 scanner buttons on admin navbar, removed the bottom one